### PR TITLE
Added a more descriptive error for JSON decoding errors

### DIFF
--- a/pro/v1/coinmarketcap.go
+++ b/pro/v1/coinmarketcap.go
@@ -214,7 +214,7 @@ func (s *Client) CryptocurrencyListingsLatest(options *CryptocurrencyListingsLat
 	resp := new(Response)
 	err = json.Unmarshal(body, &resp)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("JSON Error: [%s]. Response body: [%s]", err.Error(), string(body))
 	}
 
 	var listings []*Listing


### PR DESCRIPTION
Currently, JSON errors provide absolutely no help due to them having no relevant information. This PR makes them more useful by providing the original error, as well as the response body.